### PR TITLE
Ensure camelize respects first_letter_in_uppercase

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -43,7 +43,7 @@ inflect.camelize = function(lower_case_and_underscored_word, first_letter_in_upp
   if (first_letter_in_uppercase) {
     return util.string.upcase(result);
   } else {
-    return result;
+    return util.string.downcase(result);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Pavan Kumar Sunkara <pavan.sss1991@gmail.com> (pksunkara.github.com)",
   "description": "custom inflections for nodejs",
   "main": "./lib/inflect",

--- a/test/inflector/cases.js
+++ b/test/inflector/cases.js
@@ -91,6 +91,7 @@
     },
     UnderscoreToLowerCamel: {
       "product": "product",
+      "Widget": "widget",
       "special_guest": "specialGuest",
       "application_controller": "applicationController",
       "area51_controller": "area51Controller"


### PR DESCRIPTION
I have encountered an inconsistency in the `camelize()` method.

If it is passed a string with an UppercaseFirstLetter but the second argument `first_letter_in_uppercase` is passed in as `false`, result is returned without ensuring the first letter is lower-cased.

Although the main use case appears to be changing underscore_words to camelCase, I am using it to convert paths (e.g. `My/Path/To/Something` should become `myPathToSomething`) in which case the first word is not ensured to start with a lowercase letter.

This changeset fixes the issue, and I've added this to the test suite.

Hope you accept the change & update npm soon.

Thanks,
Jed.
