### PR TITLE
Don't map non-alphanumerics to space in titleize()

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -205,7 +205,6 @@ inflect.humanize = function (lower_case_and_underscored_word) {
 inflect.titleize = function (word) {
   var self;
   self = inflect.humanize(inflect.underscore(word));
-  self = util.string.gsub(self, /[^a-zA-Z:']/, ' ');
   return util.string.capitalize(self);
 };
 

--- a/test/inflector/methods-test.js
+++ b/test/inflector/methods-test.js
@@ -301,6 +301,9 @@
         },
         'with hyphens': function(topic) {
           return assert.equal(topic.titleize('x-men: the last stand'), 'X Men: The Last Stand');
+        },
+        'with ampersands': function(topic) {
+          return assert.equal(topic.titleize('garfunkel & oates'), 'Garfunkel & Oates');
         }
       },
       'tableize': function(topic) {


### PR DESCRIPTION
Fixes #22.

I removed entirely the line that changes non-alphanumerics into spaces; doing so had no negative impact on tests. I may be unwittingly throwing the baby out with the bathwater.

I added a single test to cover the case that I was particularly concerned about.