### PR TITLE
Skip articles and prepositions in titleize()

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -195,17 +195,54 @@ inflect.humanize = function (lower_case_and_underscored_word) {
   return util.string.capitalize(result, true);
 };
 
-// Capitalizes all the words and replaces some characters in the string to create
-// a nicer looking title. _titleize_ is meant for creating pretty output. It is not
-// used in the Bullet internals.
+inflect.titleizeSkips = {
+  // articles
+  "a": true,
+  "an": true,
+  "the": true,
+
+  // prepositions
+  "about": true,
+  "after": true,
+  "against": true,
+  "among": true,
+  "around": true,
+  "as": true,
+  "at": true,
+  "before": true,
+  "between": true,
+  "by": true,
+  "during": true,
+  "for": true,
+  "from": true,
+  "in": true,
+  "into": true,
+  "like": true,
+  "of": true,
+  "on": true,
+  "out": true,
+  "over": true,
+  "through": true,
+  "to": true,
+  "under": true,
+  "with": true,
+  "without": true,
+};
+
+// Capitalizes all the words except those from the skip list and replaces some
+// characters in the string to create a nicer looking title. _titleize_ is
+// meant for creating pretty output. It is not used in the Bullet internals.
 //
 //
-//     "man from the boondocks".titleize()   // => "Man From The Boondocks"
-//     "x-men: the last stand".titleize()    // => "X Men: The Last Stand"
+//     "man from the boondocks".titleize()   // => "Man from the Boondocks"
+//     "x-men: the last stand".titleize()    // => "X Men: the Last Stand"
 inflect.titleize = function (word) {
   var self;
   self = inflect.humanize(inflect.underscore(word));
-  return util.string.capitalize(self);
+  return self.split(' ').map(function(word) {
+    return inflect.titleizeSkips[word] ?
+      word : util.string.capitalize(word, true);
+  }).join(' ');
 };
 
 // Create the name of a table like Bullet does for models to table names. This method

--- a/test/inflector/cases.js
+++ b/test/inflector/cases.js
@@ -155,7 +155,9 @@
       'Bulletwebservice': 'Bulletwebservice',
       "pavan's code": "Pavan's Code",
       "Pavan's code": "Pavan's Code",
-      "pavan's Code": "Pavan's Code"
+      "pavan's Code": "Pavan's Code",
+      "man from the boondocks" : "Man from the Boondocks",
+      "the man from the boondocks": "The Man from the Boondocks"
     },
     OrdinalNumbers: {
       "-1": "-1st",

--- a/test/inflector/methods-test.js
+++ b/test/inflector/methods-test.js
@@ -300,7 +300,7 @@
           return _results;
         },
         'with hyphens': function(topic) {
-          return assert.equal(topic.titleize('x-men: the last stand'), 'X Men: The Last Stand');
+          return assert.equal(topic.titleize('x-men: the last stand'), 'X Men: the Last Stand');
         },
         'with ampersands': function(topic) {
           return assert.equal(topic.titleize('garfunkel & oates'), 'Garfunkel & Oates');


### PR DESCRIPTION
Defines a dictionary of articles and prepositions, and leaves them in their lowercase form when calling titleize().

This leads to more typical titleizations.